### PR TITLE
Empty Image Place Holder

### DIFF
--- a/app/src/main/java/com/example/thepickleapp/presentation/common_views/general/PickleImageView.kt
+++ b/app/src/main/java/com/example/thepickleapp/presentation/common_views/general/PickleImageView.kt
@@ -6,13 +6,16 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Text
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.drawable.toBitmap
@@ -20,6 +23,7 @@ import coil.compose.AsyncImagePainter
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import coil.size.Size
+import com.example.thepickleapp.R
 import com.example.thepickleapp.presentation.common_views.EmptyLoadingScreen
 import com.example.thepickleapp.presentation.ui.theme.pickleAppColors
 
@@ -33,7 +37,7 @@ fun PickleImageView(
         model = ImageRequest.Builder(LocalContext.current)
             .data(url)
             .allowHardware(false)
-            .size(Size.ORIGINAL) // Set the target size to load the image at.
+            .size(Size.ORIGINAL)
             .build(),
         contentScale = ContentScale.FillBounds
     )
@@ -53,18 +57,28 @@ fun PickleImageView(
                 ImageSuccessContainer((painter.state as AsyncImagePainter.State.Success).result.drawable)
             }
 
-            is AsyncImagePainter.State.Error -> {
-                Text(text = "Loding Image Error")
-            }
-
             is AsyncImagePainter.State.Loading -> {
                 EmptyLoadingScreen(modifier = Modifier.fillMaxSize())
             }
 
-            is AsyncImagePainter.State.Empty -> {
-                Text(text = "Loding Image Error")
+            else -> {
+                EmptyImagePlaceHolder()
             }
         }
+    }
+}
+
+@Composable
+fun EmptyImagePlaceHolder() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            painter = painterResource(id = R.drawable.baseline_image_24),
+            contentDescription = null,
+            tint = pickleAppColors().onSearchBarHint
+        )
     }
 }
 
@@ -77,3 +91,10 @@ fun ImageSuccessContainer(result: Drawable) {
         contentScale = ContentScale.FillBounds
     )
 }
+
+@Preview(showBackground = true, widthDp = 80, heightDp = 80)
+@Composable
+fun EmptyImagePlaceHolderPreview() {
+    EmptyImagePlaceHolder()
+}
+

--- a/app/src/main/res/drawable/baseline_image_24.xml
+++ b/app/src/main/res/drawable/baseline_image_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z"/>
+</vector>


### PR DESCRIPTION
- A new EmptyImagePlaceHolder is created to cover the no image and error while loading image paths for all cards loading images.
- baseline_image_24.xml is added to serve as replacement image