### PR TITLE
Paging Error View

### DIFF
--- a/app/src/main/java/com/example/thepickleapp/data/dao/PickleResultDaoBase.kt
+++ b/app/src/main/java/com/example/thepickleapp/data/dao/PickleResultDaoBase.kt
@@ -5,12 +5,15 @@ import com.example.thepickleapp.data.dao.character.LocationShortDao
 import com.google.gson.annotations.SerializedName
 
 @Keep
+open class PickleResultBase
+
+@Keep
 open class PickleResultDaoBase(
     @SerializedName("id")
     val id: Int?,
     @SerializedName("name")
     val name: String?
-)
+) : PickleResultBase()
 
 @Keep
 data class CharacterDao(
@@ -78,6 +81,11 @@ data class EpisodeDao(
     id = episodeId,
     name = episodeName
 )
+
+data class PagingError(
+    val errorTitle: String?,
+    val errorMessage: String?
+) : PickleResultBase()
 
 
 

--- a/app/src/main/java/com/example/thepickleapp/di/AppModule.kt
+++ b/app/src/main/java/com/example/thepickleapp/di/AppModule.kt
@@ -11,6 +11,7 @@ import com.example.thepickleapp.domain.repo.LocationsRepository
 import com.example.thepickleapp.domain.use_cases.GetCharactersUseCase
 import com.example.thepickleapp.domain.use_cases.GetEpisodesUseCase
 import com.example.thepickleapp.domain.use_cases.GetLocationsUseCase
+import com.example.thepickleapp.domain.utils.Paginator
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -68,7 +69,7 @@ object AppModule {
     fun provideGetCharactersUseCase(
         repository: CharacterRepository
     ): GetCharactersUseCase {
-        return GetCharactersUseCase(repository)
+        return GetCharactersUseCase(repository, Paginator)
     }
 
     @Provides
@@ -76,7 +77,7 @@ object AppModule {
     fun provideGetEpisodesUseCase(
         repository: EpisodesRepository
     ): GetEpisodesUseCase {
-        return GetEpisodesUseCase(repository)
+        return GetEpisodesUseCase(repository, Paginator)
     }
 
     @Provides
@@ -84,6 +85,6 @@ object AppModule {
     fun provideGetLocationsUseCase(
         repository: LocationsRepository
     ): GetLocationsUseCase {
-        return GetLocationsUseCase(repository)
+        return GetLocationsUseCase(repository, Paginator)
     }
 }

--- a/app/src/main/java/com/example/thepickleapp/domain/use_cases/BaseUseCase.kt
+++ b/app/src/main/java/com/example/thepickleapp/domain/use_cases/BaseUseCase.kt
@@ -1,0 +1,83 @@
+package com.example.thepickleapp.domain.use_cases
+
+import com.example.thepickleapp.data.dao.ResponseContainerBase
+import com.example.thepickleapp.data.result_wrapper.PickleRequestResult
+import com.example.thepickleapp.domain.utils.Paginator
+import com.example.thepickleapp.presentation.screens.main_screen.MainScreenUiState
+import com.example.thepickleapp.presentation.screens.main_screen.search.state.QueryState
+import com.example.thepickleapp.presentation.utils.ErrorData
+import com.example.thepickleapp.presentation.utils.ErrorUtils
+
+open class BaseUseCase(
+    val paginator : Paginator
+) {
+
+    private var isFetching: Boolean = false
+
+    protected fun shouldFetch(): Boolean {
+        return paginator.pagingEnabled()
+                && !isFetching
+    }
+
+    protected fun verifyResultType(queryState: QueryState?) {
+        paginator.verifyResultType(queryState)
+    }
+
+    protected fun setFetching(fetching: Boolean) {
+        isFetching = fetching
+    }
+
+    protected fun getLoadingState(): MainScreenUiState {
+        return if (paginator.results.isNotEmpty()) {
+            paginator.isPaging = true
+            MainScreenUiState.Success(
+                data = paginator.results,
+                isPaging = paginator.isPaging,
+                isLastPage = paginator.isFinalPage
+            )
+
+        } else {
+            MainScreenUiState.Loading
+        }
+    }
+
+    protected fun getSuccessState(
+        response: PickleRequestResult<ResponseContainerBase>
+    ): MainScreenUiState {
+        return if (response.data != null) {
+            paginator.addSucccess(
+                response.data
+            )
+            MainScreenUiState.Success(
+                data = paginator.results,
+                isPaging = paginator.isPaging,
+                isLastPage = paginator.isFinalPage
+            )
+        } else {
+            MainScreenUiState.Error(errorData = ErrorUtils.getDefaultErrorData())
+        }
+    }
+
+    protected fun getErrorState(response: PickleRequestResult<ResponseContainerBase>): MainScreenUiState {
+        if (paginator.results.isEmpty()) {
+            return MainScreenUiState.Error(
+                errorData = ErrorData(
+                    errorTitle = "Ups! Something went wrong!",
+                    errorMessage = response.errorMessage
+                )
+            )
+
+        } else {
+            paginator.addError(
+                response.status,
+                response.errorMessage
+            )
+            return MainScreenUiState.Success(
+                data = paginator.results,
+                isPaging = paginator.isPaging,
+                isLastPage = paginator.isFinalPage
+            )
+
+        }
+    }
+}

--- a/app/src/main/java/com/example/thepickleapp/domain/use_cases/GetCharactersUseCase.kt
+++ b/app/src/main/java/com/example/thepickleapp/domain/use_cases/GetCharactersUseCase.kt
@@ -4,88 +4,48 @@ import com.example.thepickleapp.data.result_wrapper.PickleResponseStatus
 import com.example.thepickleapp.domain.repo.CharacterRepository
 import com.example.thepickleapp.domain.utils.Paginator
 import com.example.thepickleapp.presentation.screens.main_screen.MainScreenUiState
+import com.example.thepickleapp.presentation.screens.main_screen.search.state.ExtraFiltersData
 import com.example.thepickleapp.presentation.screens.main_screen.search.state.QueryState
-import com.example.thepickleapp.presentation.screens.main_screen.search.state.getParamStringValue
-import com.example.thepickleapp.presentation.utils.ErrorData
-import com.example.thepickleapp.presentation.utils.ErrorUtils
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class GetCharactersUseCase @Inject constructor(
     private val repository: CharacterRepository,
-    private val paginator: Paginator = Paginator
-) {
-    private var isFetching : Boolean = false
-    suspend operator fun invoke(queryData: QueryState?): Flow<MainScreenUiState> = flow {
-        paginator.verifyResultType(queryData)
-        if (!paginator.isFinalPage && !paginator.isPaging && !isFetching) {
-            isFetching = true
-            if (paginator.results.isNotEmpty()) {
-                paginator.isPaging = true
-                emit(
-                    MainScreenUiState.Success(
-                        data = paginator.results,
-                        isPaging = paginator.isPaging,
-                        isLastPage = paginator.isFinalPage
-                    )
-                )
-            } else {
-                emit(
-                    MainScreenUiState.Loading
-                )
-            }
+    paginator: Paginator
+) : BaseUseCase(paginator) {
 
+    suspend operator fun invoke(queryData: QueryState?): Flow<MainScreenUiState> = flow {
+
+        verifyResultType(queryData)
+        val extraFiltersData = queryData?.extraFiltersState?.extraFiltersData
+        if (extraFiltersData is ExtraFiltersData.CharacterExtraFilters?
+            && shouldFetch()
+        ) {
+            setFetching(true)
+            emit(getLoadingState())
             val response = repository.getCharacters(
                 name = queryData?.query,
-                status = queryData?.getParamStringValue("status"),
-                species = queryData?.getParamStringValue("species"),
-                type = queryData?.getParamStringValue("type"),
-                gender = queryData?.getParamStringValue("gender"),
+                status = extraFiltersData?.status,
+                species = extraFiltersData?.species,
+                type = extraFiltersData?.type,
+                gender = extraFiltersData?.gender,
                 page = paginator.nextPage
             )
             when (response.status) {
                 PickleResponseStatus.SUCCESS -> {
-                    isFetching = false
-                    if (response.data != null) {
-                        paginator.addSucccess(
-                            response.data
-                        )
-                        emit(
-                            MainScreenUiState.Success(
-                                data = paginator.results,
-                                isPaging = paginator.isPaging,
-                                isLastPage = paginator.isFinalPage
-                            )
-                        )
-                    } else {
-                        MainScreenUiState.Error(errorData = ErrorUtils.getDefaultErrorData())
-                    }
+                    emit(getSuccessState(response))
                 }
 
                 PickleResponseStatus.CONNECTION_ERROR -> {
-                    isFetching = false
-                    emit(
-                        MainScreenUiState.Error(
-                            errorData = ErrorData(
-                                errorTitle = "Ups! Something went wrong!",
-                                errorMessage = "Try checking your Interdimentional Internet connection"
-                            )
-                        )
-                    )
+                    emit(getErrorState(response))
                 }
 
                 PickleResponseStatus.SERVER_ERROR -> {
-                    isFetching = false
-                    emit(
-                        MainScreenUiState.Error(
-                            errorData = ErrorData(
-                                errorTitle = "Ups! Something went wrong!",
-                                errorMessage = "We couldn't perform this action for this universe."
-                            )
-                        )
-                    )
+                    emit(getErrorState(response))
                 }
+            }.also {
+                setFetching(false)
             }
         }
     }

--- a/app/src/main/java/com/example/thepickleapp/domain/use_cases/GetEpisodesUseCase.kt
+++ b/app/src/main/java/com/example/thepickleapp/domain/use_cases/GetEpisodesUseCase.kt
@@ -6,97 +6,42 @@ import com.example.thepickleapp.domain.utils.Paginator
 import com.example.thepickleapp.presentation.screens.main_screen.MainScreenUiState
 import com.example.thepickleapp.presentation.screens.main_screen.search.state.ExtraFiltersData
 import com.example.thepickleapp.presentation.screens.main_screen.search.state.QueryState
-import com.example.thepickleapp.presentation.screens.main_screen.search.utils.EpisodeFilterType
-import com.example.thepickleapp.presentation.utils.ErrorData
-import com.example.thepickleapp.presentation.utils.ErrorUtils
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class GetEpisodesUseCase @Inject constructor(
     private val repository: EpisodesRepository,
-    private val paginator: Paginator = Paginator
-) {
-    private var isFetching : Boolean = false
+    paginator: Paginator
+) : BaseUseCase(paginator) {
 
     suspend operator fun invoke(queryData: QueryState?): Flow<MainScreenUiState> = flow {
-        paginator.verifyResultType(queryData)
-        if (!paginator.isFinalPage && !paginator.isPaging && !isFetching) {
-            isFetching = true
-            if (paginator.results.isNotEmpty()) {
-                paginator.isPaging = true
-                emit(
-                    MainScreenUiState.Success(
-                        data = paginator.results,
-                        isPaging = paginator.isPaging,
-                        isLastPage = paginator.isFinalPage
-                    )
-                )
-            } else {
-                emit(
-                    MainScreenUiState.Loading
-                )
-            }
-            var queryType: String? = "Name"
-            val extraData = queryData?.extraFiltersState?.extraFiltersData
-            if (extraData is ExtraFiltersData.EpisodesExtraFilters) {
-                queryType = extraData.episodeQueryType
-            }
-            val response = if (queryType == EpisodeFilterType.episodeFilterByName) {
-                repository.getEpisodes(
-                    name = queryData?.query,
-                    episode = null,
-                    page = paginator.nextPage
-                )
-            } else {
-                repository.getEpisodes(
-                    name = null,
-                    episode = queryData?.query,
-                    page = paginator.nextPage
-                )
-            }
+        verifyResultType(queryData)
+        val extraFiltersData = queryData?.extraFiltersState?.extraFiltersData
+        if (extraFiltersData is ExtraFiltersData.EpisodesExtraFilters?
+            && shouldFetch()
+        ) {
+            setFetching(true)
+            emit(getLoadingState())
+            val response = repository.getEpisodes(
+                name = queryData?.query,
+                episode = null,
+                page = paginator.nextPage
+            )
             when (response.status) {
                 PickleResponseStatus.SUCCESS -> {
-                    isFetching = false
-                    if (response.data != null) {
-                        paginator.addSucccess(
-                            response.data
-                        )
-                        emit(
-                            MainScreenUiState.Success(
-                                data = paginator.results,
-                                isPaging = paginator.isPaging,
-                                isLastPage = paginator.isFinalPage
-                            )
-                        )
-                    } else {
-                        MainScreenUiState.Error(errorData = ErrorUtils.getDefaultErrorData())
-                    }
+                    emit(getSuccessState(response))
                 }
 
                 PickleResponseStatus.CONNECTION_ERROR -> {
-                    isFetching = false
-                    emit(
-                        MainScreenUiState.Error(
-                            errorData = ErrorData(
-                                errorTitle = "Ups! Something went wrong!",
-                                errorMessage = "Try checking your Interdimentional Internet connection"
-                            )
-                        )
-                    )
+                    emit(getErrorState(response))
                 }
 
                 PickleResponseStatus.SERVER_ERROR -> {
-                    isFetching = false
-                    emit(
-                        MainScreenUiState.Error(
-                            errorData = ErrorData(
-                                errorTitle = "Ups! Something went wrong!",
-                                errorMessage = "We couldn't perform this action for this universe."
-                            )
-                        )
-                    )
+                    emit(getErrorState(response))
                 }
+            }.also {
+                setFetching(false)
             }
         }
     }

--- a/app/src/main/java/com/example/thepickleapp/domain/use_cases/GetLocationsUseCase.kt
+++ b/app/src/main/java/com/example/thepickleapp/domain/use_cases/GetLocationsUseCase.kt
@@ -4,85 +4,45 @@ import com.example.thepickleapp.data.result_wrapper.PickleResponseStatus
 import com.example.thepickleapp.domain.repo.LocationsRepository
 import com.example.thepickleapp.domain.utils.Paginator
 import com.example.thepickleapp.presentation.screens.main_screen.MainScreenUiState
+import com.example.thepickleapp.presentation.screens.main_screen.search.state.ExtraFiltersData
 import com.example.thepickleapp.presentation.screens.main_screen.search.state.QueryState
-import com.example.thepickleapp.presentation.screens.main_screen.search.state.getParamStringValue
-import com.example.thepickleapp.presentation.utils.ErrorData
-import com.example.thepickleapp.presentation.utils.ErrorUtils
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class GetLocationsUseCase @Inject constructor(
     private val repository: LocationsRepository,
-    private val paginator: Paginator = Paginator
-) {
-    private var isFetching : Boolean = false
+    paginator: Paginator
+) : BaseUseCase(paginator) {
+
     suspend operator fun invoke(queryData: QueryState?): Flow<MainScreenUiState> = flow {
-        paginator.verifyResultType(queryData)
-        if (!paginator.isFinalPage && !paginator.isPaging && !isFetching) {
-            isFetching = true
-            if (paginator.results.isNotEmpty()) {
-                paginator.isPaging = true
-                emit(
-                    MainScreenUiState.Success(
-                        data = paginator.results,
-                        isPaging = paginator.isPaging,
-                        isLastPage = paginator.isFinalPage
-                    )
-                )
-            } else {
-                emit(
-                    MainScreenUiState.Loading
-                )
-            }
+        verifyResultType(queryData)
+        val extraFiltersData = queryData?.extraFiltersState?.extraFiltersData
+        if (extraFiltersData is ExtraFiltersData.LocationsExtraFilters?
+            && shouldFetch()
+        ) {
+            setFetching(true)
+            emit(getLoadingState())
             val response = repository.getLocations(
                 name = queryData?.query,
-                type = queryData?.getParamStringValue("type"),
-                dimension = queryData?.getParamStringValue("dimension"),
+                type = extraFiltersData?.type,
+                dimension = extraFiltersData?.dimension,
                 page = paginator.nextPage
             )
             when (response.status) {
                 PickleResponseStatus.SUCCESS -> {
-                    isFetching = false
-                    if (response.data != null) {
-                        paginator.addSucccess(
-                            response.data
-                        )
-                        emit(
-                            MainScreenUiState.Success(
-                                data = paginator.results,
-                                isPaging = paginator.isPaging,
-                                isLastPage = paginator.isFinalPage
-                            )
-                        )
-                    } else {
-                        MainScreenUiState.Error(errorData = ErrorUtils.getDefaultErrorData())
-                    }
+                    emit(getSuccessState(response))
                 }
 
                 PickleResponseStatus.CONNECTION_ERROR -> {
-                    isFetching = false
-                    emit(
-                        MainScreenUiState.Error(
-                            errorData = ErrorData(
-                                errorTitle = "Ups! Something went wrong!",
-                                errorMessage = "Try checking your Interdimentional Internet connection"
-                            )
-                        )
-                    )
+                    emit(getErrorState(response))
                 }
 
                 PickleResponseStatus.SERVER_ERROR -> {
-                    isFetching = false
-                    emit(
-                        MainScreenUiState.Error(
-                            errorData = ErrorData(
-                                errorTitle = "Ups! Something went wrong!",
-                                errorMessage = "We couldn't perform this action for this universe."
-                            )
-                        )
-                    )
+                    emit(getErrorState(response))
                 }
+            }.also {
+                setFetching(false)
             }
         }
     }

--- a/app/src/main/java/com/example/thepickleapp/domain/utils/Paginator.kt
+++ b/app/src/main/java/com/example/thepickleapp/domain/utils/Paginator.kt
@@ -1,7 +1,9 @@
 package com.example.thepickleapp.domain.utils
 
-import com.example.thepickleapp.data.dao.PickleResultDaoBase
+import com.example.thepickleapp.data.dao.PagingError
+import com.example.thepickleapp.data.dao.PickleResultBase
 import com.example.thepickleapp.data.dao.ResponseContainerBase
+import com.example.thepickleapp.data.result_wrapper.PickleResponseStatus
 import com.example.thepickleapp.presentation.screens.main_screen.search.state.QueryState
 
 object Paginator {
@@ -10,7 +12,8 @@ object Paginator {
     private var totalPages: Int? = null
     var isFinalPage: Boolean = false
     var isPaging: Boolean = false
-    var results: List<PickleResultDaoBase> = emptyList()
+    var errorOcurred: Boolean = false
+    var results: List<PickleResultBase> = emptyList()
     var currentQueryData: QueryState? = null
 
     fun addSucccess(data: ResponseContainerBase) {
@@ -51,6 +54,52 @@ object Paginator {
         totalPages = null
         isFinalPage = false
         isPaging = false
+        errorOcurred = false
         results = emptyList()
+    }
+
+    fun addError(
+        status: PickleResponseStatus,
+        errorMessage: String?
+    ) {
+        isPaging = false
+        isFinalPage = false
+        errorOcurred = true
+        val pagingError = getPagingErrorForStatus(status, errorMessage)
+        pagingError?.let {
+            results = results + pagingError
+        }
+
+    }
+
+    private fun getPagingErrorForStatus(
+        status: PickleResponseStatus,
+        errorMessage: String?
+    ): PickleResultBase? {
+        return when (status) {
+            PickleResponseStatus.SERVER_ERROR -> {
+                PagingError(
+                    errorTitle = "Ups, there was a problem!",
+                    errorMessage = errorMessage
+                        ?: "We couldn't perform this action. Try again later."
+                )
+            }
+
+            PickleResponseStatus.CONNECTION_ERROR -> {
+                PagingError(
+                    errorTitle = "Ups, there was a problem!",
+                    errorMessage = errorMessage
+                        ?: "Verify your interdimensional internet connection."
+                )
+            }
+
+            else -> {
+                null
+            }
+        }
+    }
+
+    fun pagingEnabled(): Boolean {
+       return !isFinalPage && !isPaging && !errorOcurred
     }
 }

--- a/app/src/main/java/com/example/thepickleapp/presentation/common_views/general/PagingErrorView.kt
+++ b/app/src/main/java/com/example/thepickleapp/presentation/common_views/general/PagingErrorView.kt
@@ -1,0 +1,104 @@
+package com.example.thepickleapp.presentation.common_views.general
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.thepickleapp.R
+import com.example.thepickleapp.data.dao.PagingError
+import com.example.thepickleapp.presentation.ui.theme.pickleAppLightColors
+
+@Composable
+fun PagingErrorView(
+    item: PagingError? = null
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .padding(vertical = 6.dp)
+    ) {
+        val leftBrush =
+            Brush.horizontalGradient(
+                colors = listOf(
+                    Color.Transparent,
+                    pickleAppLightColors().onSurface
+                )
+            )
+        val rightBrush =
+            Brush.horizontalGradient(
+                colors = listOf(
+                    pickleAppLightColors().onSurface,
+                    Color.Transparent
+                )
+            )
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .height(8.dp)
+                    .clip(RoundedCornerShape(100))
+                    .background(leftBrush)
+            )
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    modifier = Modifier
+                        .fillMaxWidth(0.7f)
+                        .padding(horizontal = 8.dp),
+                    text = item?.errorTitle ?: stringResource(id = R.string.base_error_title),
+                    textAlign = TextAlign.Center,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    lineHeight = 14.sp
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    modifier = Modifier
+                        .fillMaxWidth(0.7f)
+                        .padding(horizontal = 8.dp),
+                    text = item?.errorMessage ?: stringResource(id = R.string.base_error_message),
+                    textAlign = TextAlign.Center,
+                    fontSize = 14.sp,
+                    lineHeight = 14.sp
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .height(8.dp)
+                    .clip(RoundedCornerShape(100))
+                    .background(rightBrush)
+            )
+        }
+
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360)
+@Composable
+fun PagingErrorViewPreview() {
+    PagingErrorView()
+}

--- a/app/src/main/java/com/example/thepickleapp/presentation/common_views/list_cells/PagingCell.kt
+++ b/app/src/main/java/com/example/thepickleapp/presentation/common_views/list_cells/PagingCell.kt
@@ -1,4 +1,4 @@
-package com.example.thepickleapp.presentation.common_views.general
+package com.example.thepickleapp.presentation.common_views.list_cells
 
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat

--- a/app/src/main/java/com/example/thepickleapp/presentation/screens/main_screen/MainListView.kt
+++ b/app/src/main/java/com/example/thepickleapp/presentation/screens/main_screen/MainListView.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -14,7 +13,8 @@ import com.example.thepickleapp.data.dao.LocationDao
 import com.example.thepickleapp.data.dao.PagingError
 import com.example.thepickleapp.data.dao.PickleResultBase
 import com.example.thepickleapp.presentation.common_views.general.EndOfListView
-import com.example.thepickleapp.presentation.common_views.general.PagingCell
+import com.example.thepickleapp.presentation.common_views.list_cells.PagingCell
+import com.example.thepickleapp.presentation.common_views.general.PagingErrorView
 import com.example.thepickleapp.presentation.common_views.list_cells.CharacterColumnCell
 import com.example.thepickleapp.presentation.common_views.list_cells.EpisodeColumnCell
 import com.example.thepickleapp.presentation.common_views.list_cells.LocationColumnCell
@@ -50,7 +50,7 @@ fun MainListView(
                 }
 
                 is PagingError -> {
-                    Text(text = "ErrorPaging")
+                    PagingErrorView(item)
                 }
             }
         }

--- a/app/src/main/java/com/example/thepickleapp/presentation/screens/main_screen/MainListView.kt
+++ b/app/src/main/java/com/example/thepickleapp/presentation/screens/main_screen/MainListView.kt
@@ -4,13 +4,15 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.example.thepickleapp.data.dao.CharacterDao
 import com.example.thepickleapp.data.dao.EpisodeDao
 import com.example.thepickleapp.data.dao.LocationDao
-import com.example.thepickleapp.data.dao.PickleResultDaoBase
+import com.example.thepickleapp.data.dao.PagingError
+import com.example.thepickleapp.data.dao.PickleResultBase
 import com.example.thepickleapp.presentation.common_views.general.EndOfListView
 import com.example.thepickleapp.presentation.common_views.general.PagingCell
 import com.example.thepickleapp.presentation.common_views.list_cells.CharacterColumnCell
@@ -19,7 +21,7 @@ import com.example.thepickleapp.presentation.common_views.list_cells.LocationCol
 
 @Composable
 fun MainListView(
-    listState: List<PickleResultDaoBase>,
+    listState: List<PickleResultBase>,
     isPaging: Boolean,
     noMoreResults: Boolean,
     endWasReached: () -> Unit
@@ -45,6 +47,10 @@ fun MainListView(
 
                 is LocationDao -> {
                     LocationColumnCell(item)
+                }
+
+                is PagingError -> {
+                    Text(text = "ErrorPaging")
                 }
             }
         }

--- a/app/src/main/java/com/example/thepickleapp/presentation/screens/main_screen/MainScreenUiState.kt
+++ b/app/src/main/java/com/example/thepickleapp/presentation/screens/main_screen/MainScreenUiState.kt
@@ -1,11 +1,11 @@
 package com.example.thepickleapp.presentation.screens.main_screen
 
-import com.example.thepickleapp.data.dao.PickleResultDaoBase
+import com.example.thepickleapp.data.dao.PickleResultBase
 import com.example.thepickleapp.presentation.utils.ErrorData
 
 sealed class MainScreenUiState {
     data class Success(
-        val data: List<PickleResultDaoBase>,
+        val data: List<PickleResultBase>,
         val isPaging : Boolean,
         val isLastPage : Boolean
     ) : MainScreenUiState()

--- a/app/src/main/java/com/example/thepickleapp/presentation/screens/main_screen/search/state/ExtraFiltersData.kt
+++ b/app/src/main/java/com/example/thepickleapp/presentation/screens/main_screen/search/state/ExtraFiltersData.kt
@@ -1,6 +1,7 @@
 package com.example.thepickleapp.presentation.screens.main_screen.search.state
 
 sealed class ExtraFiltersData {
+
     data class CharacterExtraFilters(
         val status: String?,
         val gender: String?,


### PR DESCRIPTION
- The BaseUseCase class is created to absorb the functions that are part of all useCases across the app.
- GetCharactersUseCase, GetLocationsUseCase and GetEpisodesUseCase now extend from BaseUseCase to avoid repeting code
- A new variable, called errorOcurred, is added to the Paginator object to track wether there was a service error while fetching more elements to fill that has already been populated. Other functions are created in Paginator to assist with this task.
- PickleResultBase is created. This open class is used to be extendend by PickleResultBase and PagingError. And MainScreenUiState and MainListView are made to consume this class. That way both results and paging errors can be passed to the lists.
- The PagingErrorView is created.
- Paging cell is relocated to the list_cells directory.