### PR TITLE
Image Caching

### DIFF
--- a/app/src/main/java/com/example/thepickleapp/presentation/common_views/general/PickleImageView.kt
+++ b/app/src/main/java/com/example/thepickleapp/presentation/common_views/general/PickleImageView.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.graphics.drawable.toBitmap
 import coil.compose.AsyncImagePainter
 import coil.compose.rememberAsyncImagePainter
+import coil.request.CachePolicy
 import coil.request.ImageRequest
 import coil.size.Size
 import com.example.thepickleapp.R
@@ -36,8 +37,8 @@ fun PickleImageView(
     val painter = rememberAsyncImagePainter(
         model = ImageRequest.Builder(LocalContext.current)
             .data(url)
-            .allowHardware(false)
-            .size(Size.ORIGINAL)
+            .diskCachePolicy(CachePolicy.ENABLED)
+            .size(Size(300, 300))
             .build(),
         contentScale = ContentScale.FillBounds
     )


### PR DESCRIPTION
- DiskCachePolicy is set to Enabled for the coil ImageRequest.
- For the ImageRequest, the size is set fixed to 300 pixels width and heigth. This is to reduce the weight for each pictured that is cached.
- For the ImageRequest the allowHardware is disabled, since the app has no use for this feature.