### PR TITLE
Response Caching

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:name=".PickleApp"

--- a/app/src/main/java/com/example/thepickleapp/data/remote/NetworkingUtils.kt
+++ b/app/src/main/java/com/example/thepickleapp/data/remote/NetworkingUtils.kt
@@ -1,0 +1,47 @@
+package com.example.thepickleapp.data.remote
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import okhttp3.Cache
+import okhttp3.OkHttpClient
+import java.io.File
+
+object NetworkingUtils {
+
+    fun provideCachingClient(context: Context): OkHttpClient {
+        val cacheSize = (5 * 1024 * 1024).toLong()
+        val child = "http-cache"
+        val myCache = Cache(File(context.cacheDir, child), cacheSize)
+
+        return OkHttpClient.Builder()
+            .cache(myCache)
+            .addInterceptor { chain ->
+                var request = chain.request()
+                request = if (hasNetwork(context)) {
+                    request.newBuilder().header("Cache-Control", "public, max-age=" + 5).build()
+                } else {
+                    request.newBuilder().header(
+                        "Cache-Control",
+                        "public, only-if-cached, max-stale=" + 60 * 60 * 24 * 7
+                    ).build()
+                }
+                chain.proceed(request)
+            }
+            .build()
+    }
+
+
+    private fun hasNetwork(appContext: Context): Boolean {
+        val connectivityManager =
+            appContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val network = connectivityManager.activeNetwork ?: return false
+        val activeNetwork = connectivityManager.getNetworkCapabilities(network) ?: return false
+
+        return when {
+            activeNetwork.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> true
+            activeNetwork.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> true
+            else -> false
+        }
+    }
+}

--- a/app/src/main/java/com/example/thepickleapp/di/AppModule.kt
+++ b/app/src/main/java/com/example/thepickleapp/di/AppModule.kt
@@ -1,6 +1,8 @@
 package com.example.thepickleapp.di
 
+import android.content.Context
 import com.example.thepickleapp.BuildConfig
+import com.example.thepickleapp.data.remote.NetworkingUtils
 import com.example.thepickleapp.data.repo.CharacterRepositoryImplementation
 import com.example.thepickleapp.data.remote.api.RickAndMortyApi
 import com.example.thepickleapp.data.repo.EpisodesRepositoryImplementation
@@ -15,6 +17,7 @@ import com.example.thepickleapp.domain.utils.Paginator
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -26,12 +29,22 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun provideApi(): RickAndMortyApi {
+    fun provideApi(
+        @ApplicationContext appContext: Context,
+        networkingUtils : NetworkingUtils
+    ): RickAndMortyApi {
         return Retrofit.Builder()
             .baseUrl(BuildConfig.BASE_URL)
             .addConverterFactory(GsonConverterFactory.create())
+            .client(networkingUtils.provideCachingClient(appContext))
             .build()
             .create(RickAndMortyApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun providesNetworkingUtils(): NetworkingUtils {
+        return NetworkingUtils
     }
 
     @Provides

--- a/app/src/main/java/com/example/thepickleapp/domain/use_cases/GetCharactersUseCase.kt
+++ b/app/src/main/java/com/example/thepickleapp/domain/use_cases/GetCharactersUseCase.kt
@@ -25,11 +25,11 @@ class GetCharactersUseCase @Inject constructor(
             setFetching(true)
             emit(getLoadingState())
             val response = repository.getCharacters(
-                name = queryData?.query,
-                status = extraFiltersData?.status,
-                species = extraFiltersData?.species,
-                type = extraFiltersData?.type,
-                gender = extraFiltersData?.gender,
+                name = queryData?.query.let { if (!it.isNullOrEmpty()) it else null },
+                status = extraFiltersData?.status.let { if (!it.isNullOrEmpty()) it else null },
+                species = extraFiltersData?.species.let { if (!it.isNullOrEmpty()) it else null },
+                type = extraFiltersData?.type.let { if (!it.isNullOrEmpty()) it else null },
+                gender = extraFiltersData?.gender.let { if (!it.isNullOrEmpty()) it else null },
                 page = paginator.nextPage
             )
             when (response.status) {

--- a/app/src/main/java/com/example/thepickleapp/domain/use_cases/GetEpisodesUseCase.kt
+++ b/app/src/main/java/com/example/thepickleapp/domain/use_cases/GetEpisodesUseCase.kt
@@ -24,7 +24,7 @@ class GetEpisodesUseCase @Inject constructor(
             setFetching(true)
             emit(getLoadingState())
             val response = repository.getEpisodes(
-                name = queryData?.query,
+                name = queryData?.query.let { if (!it.isNullOrEmpty()) it else null },
                 episode = null,
                 page = paginator.nextPage
             )

--- a/app/src/main/java/com/example/thepickleapp/domain/use_cases/GetLocationsUseCase.kt
+++ b/app/src/main/java/com/example/thepickleapp/domain/use_cases/GetLocationsUseCase.kt
@@ -25,8 +25,8 @@ class GetLocationsUseCase @Inject constructor(
             emit(getLoadingState())
             val response = repository.getLocations(
                 name = queryData?.query,
-                type = extraFiltersData?.type,
-                dimension = extraFiltersData?.dimension,
+                type = extraFiltersData?.type.let { if (!it.isNullOrEmpty()) it else null },
+                dimension = extraFiltersData?.dimension.let { if (!it.isNullOrEmpty()) it else null },
                 page = paginator.nextPage
             )
             when (response.status) {


### PR DESCRIPTION
- Permission for checking networkAccess is added to manifest
- NetworkingUtils class is created to provide an OkHttpClient with an interceptor that checks if there is internet access. If connected, then stores the responses in a key-value in cache. If not, checks if there are responses cached for that key and responds with them.
- AppModule is changed so when providing the RickAndMortyApi to the Repository, NetworkingUtils is also injected.
- The requests in all UseCases have been changes so as to pass a null value instead of an empty string. This way, whenever a field is empty is always treated the same way. This is so that when not connected and after adding and deleting a filter, we can obtain the same response.